### PR TITLE
Small automatic cleanup implementation, small bug fixes

### DIFF
--- a/Source/BlueprintTaskForge/Private/BtfTaskForge.cpp
+++ b/Source/BlueprintTaskForge/Private/BtfTaskForge.cpp
@@ -120,17 +120,6 @@ void
 //++CK
 auto
     UBtf_TaskForge::
-    DoRequest_AddTaskToDeactivateOnDeactivate(
-        UBtf_TaskForge* InTask)
-    -> void
-{
-    _TasksToDeactivateOnDeactivate.Emplace(InTask);
-}
-//--CK
-
-//++CK
-auto
-    UBtf_TaskForge::
     OnDestroy()
     -> void
 {
@@ -170,6 +159,31 @@ void UBtf_TaskForge::Serialize(FArchive& Ar)
         }
     }
 #endif
+}
+
+void UBtf_TaskForge::SetupAutomaticCleanup()
+{
+    if(GetOuter() == nullptr)
+    {
+        return;
+    }
+
+    if(GetOuter()->IsA<AActor>())
+    {
+        if(AActor* Actor = Cast<AActor>(GetOuter()))
+        {
+            Actor->OnDestroyed.AddDynamic(this, &UBtf_TaskForge::OnActorOuterDestroyed);
+            return;
+        }
+    }
+
+    if(GetOuter()->IsA<UBtf_TaskForge>())
+    {
+        if(UBtf_TaskForge* TaskTemplate = Cast<UBtf_TaskForge>(GetOuter()))
+        {
+            TaskTemplate->TrackTaskForAutomaticDeactivation(this);
+        }
+    }
 }
 
 //++CK

--- a/Source/BlueprintTaskForge/Public/Subsystem/BtfSubsystem.h
+++ b/Source/BlueprintTaskForge/Public/Subsystem/BtfSubsystem.h
@@ -34,6 +34,11 @@ public:
     Request_UntrackTask(
         UBtf_TaskForge* InTask) -> void;
 
+    TMap<TWeakObjectPtr<UObject>, FBtf_OutersBlueprintTasksArrayWrapper> GetTaskTree()
+    {
+        return ObjectsAndTheirTasks;
+    }
+
 private:
     UPROPERTY(Transient)
     TSet<TObjectPtr<UBtf_TaskForge>> _BlueprintTasks;

--- a/Source/BlueprintTaskForgeEditor/Private/BlueprintTaskForgeEditor_Module.cpp
+++ b/Source/BlueprintTaskForgeEditor/Private/BlueprintTaskForgeEditor_Module.cpp
@@ -35,7 +35,7 @@ void FBlueprintTaskForgeEditorModule::StartupModule()
 
 	//BNT node customization
 	PropertyModule.RegisterCustomClassLayout(
-		"K2Node_Blueprint_Template",
+		UBtf_TaskForge_K2Node::StaticClass()->GetFName(),
 		FOnGetDetailCustomizationInstance::CreateStatic(&FBtf_NodeDetailsCustomizations::MakeInstance)
 	);
 

--- a/Source/BlueprintTaskForgeEditor/Private/BtfTaskForge_K2Node.cpp
+++ b/Source/BlueprintTaskForgeEditor/Private/BtfTaskForge_K2Node.cpp
@@ -61,35 +61,34 @@ void UBtf_TaskForge_K2Node::RegisterBlueprintAction(UClass* TargetClass, FBluepr
             FBlueprintActionUiSpec& MenuSignature = NodeSpawner->DefaultMenuSignature;
 
 //++CK
-            if (TargetClass->HasAnyClassFlags(CLASS_CompiledFromBlueprint))
+            
+            FString LocName = TargetClass->GetName();
+            LocName.RemoveFromEnd(FNames_Helper::CompiledFromBlueprintSuffix);
+
+            if (const UBtf_TaskForge* TargetClassAsBlueprintTask = Cast<UBtf_TaskForge>(TargetClass->ClassDefaultObject))
             {
-                FString LocName = TargetClass->GetName();
-                LocName.RemoveFromEnd(FNames_Helper::CompiledFromBlueprintSuffix);
-
-                if (const UBtf_TaskForge* TargetClassAsBlueprintTask = Cast<UBtf_TaskForge>(TargetClass->ClassDefaultObject))
+                if (TargetClassAsBlueprintTask->Category != NAME_None)
                 {
-                    if (TargetClassAsBlueprintTask->Category != NAME_None)
-                    {
-                        MenuSignature.Category = FText::FromName(TargetClassAsBlueprintTask->Category);
-                    }
-
-                    if (TargetClassAsBlueprintTask->Tooltip != NAME_None)
-                    {
-                        MenuSignature.Tooltip = FText::FromName(TargetClassAsBlueprintTask->Tooltip);
-                    }
-
-                    MenuSignature.MenuName = TargetClassAsBlueprintTask->MenuDisplayName != NAME_None
-                                                ? FText::FromName(TargetClassAsBlueprintTask->MenuDisplayName)
-                                                : FText::FromString(LocName);
-
-                    MenuSignature.Keywords = MenuSignature.MenuName;
+                    MenuSignature.Category = FText::FromName(TargetClassAsBlueprintTask->Category);
                 }
-                else
+
+                if (TargetClassAsBlueprintTask->Tooltip != NAME_None)
                 {
-                    MenuSignature.MenuName = FText::FromString(LocName);
-                    MenuSignature.Keywords = FText::FromString(LocName);
+                    MenuSignature.Tooltip = FText::FromName(TargetClassAsBlueprintTask->Tooltip);
                 }
+
+                MenuSignature.MenuName = TargetClassAsBlueprintTask->MenuDisplayName != NAME_None
+                                            ? FText::FromName(TargetClassAsBlueprintTask->MenuDisplayName)
+                                            : FText::FromString(LocName);
+
+                MenuSignature.Keywords = MenuSignature.MenuName;
             }
+            else
+            {
+                MenuSignature.MenuName = FText::FromString(LocName);
+                MenuSignature.Keywords = FText::FromString(LocName);
+            }
+            
 //--CK
 
             NodeSpawner->CustomizeNodeDelegate = UBlueprintNodeSpawner::FCustomizeNodeDelegate::CreateLambda(CustomizeTimelineNodeLambda, FunctionPtr);


### PR DESCRIPTION
Fixes:
- C++ nodes weren't appearing the context menu and task palette correctly
- Added getter for a variable that was made private
- Custom details panel for nodes weren't working, making node instances uneditable

Added:
- Small and simple implementation of automatic cleanup. [Commit](e56f666ee944fdca5bb18794c9b4296d7e8c7b38) has more info