### PR TITLE
Bugfix/delegate bugs

### DIFF
--- a/Source/BlueprintTaskForge/Private/BtfTaskForge.cpp
+++ b/Source/BlueprintTaskForge/Private/BtfTaskForge.cpp
@@ -483,6 +483,8 @@ void UBtf_TaskForge::RefreshCollected()
         AutoCallFunction.AddUnique(FBtf_NameSelect{TEXT("Activate")});
 
         AutoCallFunction.Remove(FBtf_NameSelect{TEXT("Deactivate")});
+        InDelegate.Remove(FBtf_NameSelect{TEXT("OnCustomPinTriggered")});
+        OutDelegate.Remove(FBtf_NameSelect{TEXT("OnCustomPinTriggered")});
 
         if (const auto* DeveloperSettings = GetDefault<UBtf_RuntimeSettings>())
         {

--- a/Source/BlueprintTaskForge/Private/BtfTaskForge.cpp
+++ b/Source/BlueprintTaskForge/Private/BtfTaskForge.cpp
@@ -33,24 +33,21 @@ UBtf_TaskForge* UBtf_TaskForge::BlueprintTaskForge(UObject* Outer, const TSubcla
     if (NOT IsValid(Outer) || NOT IsValid(Class) || Class->HasAnyClassFlags(CLASS_Abstract))
     { return nullptr; }
 
-    if (auto* TaskTemplate = GetTaskByNodeGUID(Outer, NodeGuidStr))
+    auto* TaskTemplate = GetTaskByNodeGUID(Outer, NodeGuidStr);
+
+    const auto TaskObjName = MakeUniqueObjectName(Outer, Class, Class->GetFName(), EUniqueObjectNameOptions::GloballyUnique);
+    const auto Task = NewObject<UBtf_TaskForge>(Outer, Class, TaskObjName, RF_NoFlags, TaskTemplate);
+
+    if (NOT IsValid(Task))
+    { return Task; }
+
+    if (const auto& BlueprintTaskEngineSystem = GEngine->GetEngineSubsystem<UBtf_EngineSubsystem>();
+        IsValid(BlueprintTaskEngineSystem))
     {
-        const auto TaskObjName = MakeUniqueObjectName(Outer, Class, Class->GetFName(), EUniqueObjectNameOptions::GloballyUnique);
-        const auto Task = NewObject<UBtf_TaskForge>(Outer, Class, TaskObjName, RF_NoFlags, TaskTemplate);
-
-        if (NOT IsValid(Task))
-        { return Task; }
-
-        if (const auto& BlueprintTaskEngineSystem = GEngine->GetEngineSubsystem<UBtf_EngineSubsystem>();
-            IsValid(BlueprintTaskEngineSystem))
-        {
-            BlueprintTaskEngineSystem->Add(FGuid(NodeGuidStr), Task);
-        }
-
-        return Task;
+        BlueprintTaskEngineSystem->Add(FGuid(NodeGuidStr), Task);
     }
 
-    return nullptr;
+    return Task;
 }
 
 UBtf_TaskForge* UBtf_TaskForge::GetTaskByNodeGUID(UObject* Outer, FString NodeGUID)

--- a/Source/BlueprintTaskForgeEditor/Private/BtfExtendConstructObject_K2Node.cpp
+++ b/Source/BlueprintTaskForgeEditor/Private/BtfExtendConstructObject_K2Node.cpp
@@ -1538,7 +1538,7 @@ void UBtf_ExtendConstructObject_K2Node::CreatePinsForClass(UClass* TargetClass, 
         {
             if (Name != NAME_None)
             {
-                if (NOT TargetClass->FindPropertyByName(Name))
+                if (NOT TargetClass->FindFunctionByName(Name))
                 { return true; }
             }
             return false;

--- a/Source/BlueprintTaskForgeEditor/Private/BtfTaskForge_K2Node.cpp
+++ b/Source/BlueprintTaskForgeEditor/Private/BtfTaskForge_K2Node.cpp
@@ -187,7 +187,7 @@ void UBtf_TaskForge_K2Node::ReconstructNode()
                         IsValid(TriggerNode))
                     {
                         TriggerNode->CachedCustomPins = CustomPins;
-                        TriggerNode->bHasValidCachedPins = true;
+                        TriggerNode->HasValidCachedPins = true;
 
                         TriggerNode->ReconstructNode();
                     }

--- a/Source/BlueprintTaskForgeEditor/Public/BtfTriggerCustomOutputPin_K2Node.h
+++ b/Source/BlueprintTaskForgeEditor/Public/BtfTriggerCustomOutputPin_K2Node.h
@@ -73,7 +73,7 @@ public:
 
     // Flag to indicate if cached pins are valid
     UPROPERTY()
-    bool bHasValidCachedPins = false;
+    bool HasValidCachedPins = false;
 
     // Dropdown support
     UFUNCTION()


### PR DESCRIPTION
commit ac55e75a46d6a59eb797030069b4c4a722012a03 (HEAD -> Bugfix/DelegateBugs, origin/Bugfix/DelegateBugs)
Author: AlexObatake <aobatake1515@gmail.com>
Date:   Thu Jul 10 13:29:49 2025 -0700

    fix: Tasks no longer clear function inputs

    *  Validity check for functions was checking for a property instead of a function due to a regression

commit d0e76ec0a302448cb09035f82bf10ac6dcb2e507
Author: AlexObatake <aobatake1515@gmail.com>
Date:   Thu Jul 10 13:27:26 2025 -0700

    fix: Don't allow OnCustomPinTriggered for InDelegate and OutDelegate

    *  This is an internal function that shouldn't be exposed

commit 93afa27798fcd300057ae65acb89ff60243e9e6e
Author: AlexObatake <aobatake1515@gmail.com>
Date:   Thu Jul 10 13:25:20 2025 -0700

    fix: Task is now created even if there is no template

    *  Fix regression where creating task would fail if there is no node found by GetTaskByNodeGUID

commit c63a98bf9ac97d054839851eedd095a470efb423
Author: AlexObatake <aobatake1515@gmail.com>
Date:   Thu Jul 10 13:20:54 2025 -0700

    fix: HasValidCachedPins is consistently named

    Some instances still used bHasValidCachedPins, now it's consistent